### PR TITLE
refactor:divide schema(#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 package-lock.json
+bun.lockb

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "type": "module",
   "dependencies": {
     "@apollo/server": "^4.10.2",
+    "@graphql-tools/graphql-file-loader": "^8.0.1",
+    "@graphql-tools/load": "^8.0.2",
+    "@graphql-tools/schema": "^10.0.3",
     "graphql": "^16.8.1"
   }
 }

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -1,0 +1,10 @@
+type Book {
+  id: ID
+  title: String
+  author: String
+  price: Int
+}
+
+type Query {
+  books: [Book!]!
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,15 @@
+import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader';
+import { loadSchemaSync } from '@graphql-tools/load';
+import { addResolversToSchema } from '@graphql-tools/schema';
 import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
+import { join } from 'path';
 
 // スキーマ（データ構造）
-const typeDefs = `#graphql
-  type Book {
-    id: ID
-    title: String
-    author: String
-    price: Int
-  }
-
-  type Query {
-    books: [Book]
-  }
-`;
+const __dirname = new URL(import.meta.url).pathname;
+const schema = loadSchemaSync(join(__dirname, '../../schema/schema.graphql'), {
+  loaders: [new GraphQLFileLoader()],
+});
 
 const books = [
   {
@@ -39,8 +35,7 @@ const resolvers = {
 
 // Apolloサーバ
 const server = new ApolloServer({
-  typeDefs,  // スキーマ
-  resolvers,  // リゾルバ
+  schema: addResolversToSchema({ schema, resolvers })
 });
 
 // Passing an ApolloServer instance to the `startStandaloneServer` function:


### PR DESCRIPTION
schema: ```schema/schema.graphql```
```
type Book {
  id: ID
  title: String
  author: String
  price: Int
}

type Query {
  books: [Book!]!
}
```

logic: ```index.ts```
```ts
// スキーマ（データ構造）
const __dirname = new URL(import.meta.url).pathname;
const schema = loadSchemaSync(join(__dirname, '../../schema/schema.graphql'), {
  loaders: [new GraphQLFileLoader()],
});
```

Libraries to use
```json
"@graphql-tools/graphql-file-loader": "^8.0.1",
"@graphql-tools/load": "^8.0.2",
"@graphql-tools/schema": "^10.0.3",
```